### PR TITLE
Various fixes/changes

### DIFF
--- a/cmd-clinet.go
+++ b/cmd-clinet.go
@@ -130,7 +130,7 @@ func commandAbout(args []string, env *CommandEnvironment) *discordgo.MessageEmbe
 		SetDescription(botData.BotName+" is a Discord bot written in Google's Go programming language, intended for conversation and fact-based queries.").
 		AddField("How can I use "+botData.BotName+" in my server?", "Simply open the Invite Link at the end of this message and follow the on-screen instructions.").
 		AddField("How can I help keep "+botData.BotName+" running?", "The best ways to help keep "+botData.BotName+" running are to either donate using the Donation Link or contribute to the source code using the Source Code Link, both at the end of this message.").
-		AddField("How can I use "+botData.BotName+"?", "There are many ways to make use of "+botData.BotName+".\n1) Type ``cli$help`` and try using some of the available commands.\n2) Ask "+botData.BotName+" a question, ex: ``@"+botData.BotName+"#1823, what time is it?`` or ``@"+botData.BotName+"#1823, what is DiscordApp?``.").
+		AddField("How can I use "+botData.BotName+"?", "There are many ways to make use of "+botData.BotName+".\n1) Type ``"+botData.CommandPrefix+"help`` and try using some of the available commands.\n2) Ask "+botData.BotName+" a question, ex: ``@"+botData.DiscordSession.State.User.String()+", what time is it?`` or ``@"+botData.DiscordSession.State.User.String()+", what is DiscordApp?``.").
 		AddField("Where can I join the "+botData.BotName+" Discord server?", "If you would like to get help and support with "+botData.BotName+" or experiment with the latest and greatest of "+botData.BotName+", use the Discord Server Invite Link at the end of this message.").
 		AddField("Bot Invite Link", botData.BotInviteURL).
 		AddField("Discord Server Invite Link", botData.BotDiscordURL).

--- a/cmd-random.go
+++ b/cmd-random.go
@@ -62,7 +62,5 @@ func commandZalgo(args []string, env *CommandEnvironment) *discordgo.MessageEmbe
 	fmt.Fprint(writer, []byte(strings.Join(args, " ")))
 	zalgo := buf.String()
 
-	fmt.Println(fmt.Sprintf("%v", zalgo))
-
 	return NewGenericEmbed("Zalgo", string(zalgo))
 }

--- a/cmd-xkcd.go
+++ b/cmd-xkcd.go
@@ -11,7 +11,7 @@ func commandXKCD(args []string, env *CommandEnvironment) *discordgo.MessageEmbed
 	case "latest":
 		comic, err := botData.BotClients.XKCD.Latest()
 		if err != nil {
-			return NewErrorEmbed("XKCD Error", "There was an error fetching the latest XKCD comic.")
+			return NewErrorEmbed("xkcd Error", "There was an error fetching the latest xkcd comic.")
 		}
 		return NewEmbed().
 			SetTitle("xkcd - #" + strconv.Itoa(comic.Number)).
@@ -21,7 +21,7 @@ func commandXKCD(args []string, env *CommandEnvironment) *discordgo.MessageEmbed
 	case "random":
 		comic, err := botData.BotClients.XKCD.Random()
 		if err != nil {
-			return NewErrorEmbed("XKCD Error", "There was an error fetching a random XKCD comic.")
+			return NewErrorEmbed("xkcd Error", "There was an error fetching a random xkcd comic.")
 		}
 		return NewEmbed().
 			SetTitle("xkcd - #" + strconv.Itoa(comic.Number)).
@@ -31,12 +31,12 @@ func commandXKCD(args []string, env *CommandEnvironment) *discordgo.MessageEmbed
 	default:
 		comicNumber, err := strconv.Atoi(args[0])
 		if err != nil {
-			return NewErrorEmbed("XKCD Error", "``"+args[0]+"`` is not a valid number.")
+			return NewErrorEmbed("xkcd Error", "``"+args[0]+"`` is not a valid number.")
 		}
 
 		comic, err := botData.BotClients.XKCD.Get(comicNumber)
 		if err != nil {
-			return NewErrorEmbed("XKCD Error", "There was an error fetching XKCD comic #"+args[0]+".")
+			return NewErrorEmbed("xkcd Error", "There was an error fetching xkcd comic #"+args[0]+".")
 		}
 		return NewEmbed().
 			SetTitle("xkcd - #" + args[0]).

--- a/events.go
+++ b/events.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -353,7 +354,7 @@ func discordGuildMemberAdd(session *discordgo.Session, member *discordgo.GuildMe
 		if guildSettings[member.GuildID].LogSettings.LoggingEnabled && guildSettings[member.GuildID].LogSettings.LoggingEvents.GuildMemberAdd {
 			joinedAt := member.JoinedAt
 			joinedAtTimeFormatted := ""
-			joinedAtTime, err := joinedAt.Parse()
+			joinedAtTime, err := time.Parse(time.RFC3339, joinedAt)
 			if err != nil {
 				joinedAtTimeFormatted = string(joinedAt)
 			} else {
@@ -397,7 +398,7 @@ func discordGuildMemberRemove(session *discordgo.Session, member *discordgo.Guil
 		if guildSettings[member.GuildID].LogSettings.LoggingEnabled && guildSettings[member.GuildID].LogSettings.LoggingEvents.GuildMemberRemove {
 			joinedAt := member.JoinedAt
 			joinedAtTimeFormatted := ""
-			joinedAtTime, err := joinedAt.Parse()
+			joinedAtTime, err := time.Parse(time.RFC3339, joinedAt)
 			if err != nil {
 				joinedAtTimeFormatted = string(joinedAt)
 			} else {

--- a/voice.go
+++ b/voice.go
@@ -13,7 +13,6 @@ import (
 	isoduration "github.com/channelmeter/iso8601duration"
 	"github.com/jonas747/dca"
 	"github.com/rylio/ytdl"
-	"google.golang.org/api/youtube/v3"
 )
 
 var encodeOptionsPresetHigh = &dca.EncodeOptions{
@@ -103,7 +102,7 @@ func (page *YouTubeResultNav) Prev() error {
 		return errors.New("Could not find any video results for the previous page")
 	}
 
-	page.PageNumber -= 1
+	page.PageNumber--
 	page.Results = response.Items
 	page.PrevPageToken = response.PrevPageToken
 	page.NextPageToken = response.NextPageToken
@@ -128,7 +127,7 @@ func (page *YouTubeResultNav) Next() error {
 		return errors.New("Could not find any video results for the next page")
 	}
 
-	page.PageNumber += 1
+	page.PageNumber--
 	page.Results = response.Items
 	page.PrevPageToken = response.PrevPageToken
 	page.NextPageToken = response.NextPageToken

--- a/voice.go
+++ b/voice.go
@@ -13,6 +13,7 @@ import (
 	isoduration "github.com/channelmeter/iso8601duration"
 	"github.com/jonas747/dca"
 	"github.com/rylio/ytdl"
+	youtube "google.golang.org/api/youtube/v3"
 )
 
 var encodeOptionsPresetHigh = &dca.EncodeOptions{


### PR DESCRIPTION
# Summary of changes:
a245a02 - Remove `fmt.Println()` in Zalgo command
e6cf76c - Change `-= 1` to `--` in `voice.go`
737715a - Use `botData.DiscordSession.State.User.String()` to get bot username and tag in about command, also use prefix set in config for example in about command.
16552a1 - Possibly uneeded - change `XKCD` to `xkcd` in error messages
b68714b - When building it was complaining about YouTube being undefined in `voice.go`, so I imported the YouTube API package as `youtube`
c4a4b2a - Fix build error `joinedAt.Parse undefined (type string has no field or method Parse)` by using `time.Parse(time.RFC3339, joinedAt)` ( [RFC3339 is an (rougly) extention of ISO8601](https://stackoverflow.com/questions/522251/whats-the-difference-between-iso-8601-and-rfc-3339-date-formats#522281) )